### PR TITLE
fix undefined property when iterateOnProperties

### DIFF
--- a/_site/js/main.js
+++ b/_site/js/main.js
@@ -165,7 +165,7 @@ var JoliToken = (function() {
                                 nestedObjects.push({fullPath: fullPath, source: source[property][subObject]});
                             }
                         }
-                    } else if (typeof (properties[property].properties) !== "undefined") {
+                    } else if (typeof (properties[property].properties) !== "undefined" && typeof (source[property]) !== "undefined") {
                         fullPath += "." + property;
                         iterateOnProperties(properties[property].properties, source[property], fullPath);
                     }


### PR DESCRIPTION
How to reproduce :

```
curl -XDELETE 'http://localhost:9200/test_jolitoken/'

curl -XPOST localhost:9200/test_jolitoken -d '{
    "settings" : {
        "number_of_shards" : 1
    },
    "mappings" : {
        "type1" : {
            "_source" : { "enabled" : true },
            "properties" : {
                "prix_cinema":{
                    "properties":{
                        "annee":{
                            "type":"string"
                        },
                        "gagnant": {
                            "type":"boolean"
                        },
                        "prix":{
                            "properties":{
                                "id":{
                                    "type":"long"
                                },
                                "nom":{
                                    "type":"string",
                                    "fields":{
                                        "raw":{
                                            "type": "string",
                                            "index":"not_analyzed"
                                        }
                                    }
                                }
                            }
                        }
                    }
                }
            }
        }
    }
}'

curl -XPUT 'http://localhost:9200/test_jolitoken/type1/1' -d '{
}'

curl -XPUT 'http://localhost:9200/test_jolitoken/type1/2' -d '{
  "prix_cinema": [
    {
      "annee": 2010,
      "gagnant": false,
      "prix": {
        "id": 2,
        "nom": "Lumière"
      }
    }
  ]
}'
```

When getting a document with no prix_cinema this error will apear on the
console on JoliToken and the tokens will no be displayed (document 1 in
example).

```
Uncaught TypeError: Cannot read property 'prix' of undefined
```
